### PR TITLE
Prepend temp: namespace to tags without one

### DIFF
--- a/eh-guid-report-view.user.js
+++ b/eh-guid-report-view.user.js
@@ -296,8 +296,9 @@ find this file, see <http://www.gnu.org/licenses/>.
     reportTags = reorderReportTags(reportTags);
     for (var i = 0; i < reportTags.length; i++) {
       var tag = reportTags[i];
-      console.log(tag.textContent);
-      var id = "td_" + tag.textContent.replaceAll(" ", "_");
+      var tagContent = tag.textContent.replaceAll(" ", "_");
+      tagContent = !tagContent.includes(":") ? "temp:" + tagContent : tagContent;
+      var id = "td_" + tagContent;
       var elem = document.getElementById(id);
       if (!elem) {
         if(stateSh == "show") {

--- a/eh-guid-report-view.user.js
+++ b/eh-guid-report-view.user.js
@@ -297,8 +297,7 @@ find this file, see <http://www.gnu.org/licenses/>.
     for (var i = 0; i < reportTags.length; i++) {
       var tag = reportTags[i];
       var tagContent = tag.textContent.replaceAll(" ", "_");
-      tagContent = !tagContent.includes(":") ? "temp:" + tagContent : tagContent;
-      var id = "td_" + tagContent;
+      var id = "td_" + (!tagContent.includes(":") ? "temp:" + tagContent : tagContent);
       var elem = document.getElementById(id);
       if (!elem) {
         if(stateSh == "show") {


### PR DESCRIPTION
* selectors for temp tags now have "temp:" in the id so this needs to be prepended to avoid an extra "fake" tag being added to the tag window